### PR TITLE
Update to allow for Legendary and Mythic levels

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,33 @@
+# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
+# For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
+
+name: Node.js Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - run: npm ci
+      - run: npm test
+
+  publish-npm:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          registry-url: https://registry.npmjs.org/
+      - run: npm ci
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.npm_token}}

--- a/functions/dlLevel.js
+++ b/functions/dlLevel.js
@@ -98,6 +98,13 @@ module.exports = {
         const objs = rawData.split(";");
         objs.shift();
 
+        const epicObj = {
+            0: false, // Not good, but I can't think of a string value for levels not rated Epic.
+            1: "Epic",
+            2: "Legendary",
+            3: "Mythic"
+        }
+
         let song;
         const { getOfficialSongInfo } = require("./getOfficialSongInfo");
         const { getSongInfo } = require("./getSongInfo");
@@ -125,7 +132,7 @@ module.exports = {
             password: password,
             demon: Boolean(Number(isDemon)),
             featured: Boolean(Number(isFeatured)),
-            epic: Boolean(Number(isEpic)),
+            epic: epicObj[Number(isEpic)],
             objects: objs.length - 1,
             uploaded: uploaded,
             updated: updated,

--- a/functions/dlLevel.js
+++ b/functions/dlLevel.js
@@ -132,7 +132,7 @@ module.exports = {
             password: password,
             demon: Boolean(Number(isDemon)),
             featured: Boolean(Number(isFeatured)),
-            epic: epicObj[Number(isEpic)],
+            rating: epicObj[Number(isEpic)],
             objects: objs.length - 1,
             uploaded: uploaded,
             updated: updated,
@@ -145,6 +145,10 @@ module.exports = {
             coins: coins,
             verifiedCoins: Boolean(Number(coinsVerified)),
             song: song
+
+            get epic() {
+                return Boolean(this.rating);
+            }
         }
 
         if (s[69] && s[68] != "41") {

--- a/functions/dlLevel.js
+++ b/functions/dlLevel.js
@@ -144,7 +144,7 @@ module.exports = {
             twoPlayer: Boolean(Number(is2P)),
             coins: coins,
             verifiedCoins: Boolean(Number(coinsVerified)),
-            song: song
+            song: song,
 
             get epic() {
                 return Boolean(this.rating);


### PR DESCRIPTION
Modified the `dlLevel` function to return a string for the `epic` key, since Legendary and Mythic levels use the `epic` key.
The value is `false` for non-Epic or higher levels, and this shouldn't break existing applications, as non-empty strings are truthy.